### PR TITLE
Fix broken link in the README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -74,7 +74,7 @@ git clone git@github.com:dowlinglab/pyomo-doe.git
 
 ## How do I learn more about Pyomo.DoE?
 
-The [Pyomo.DoE documentation](https://pyomo.readthedocs.io/en/stable/contributed_packages/doe/doe.html) is a great information and a different set of examples. Also see our tutorial notebook for the [reaction kinetics example](https://colab.research.google.com/github/Pyomo/pyomo/blob/main/pyomo/contrib/doe/examples/fim_doe_tutorial.ipynb).
+The [Pyomo.DoE documentation](https://pyomo.readthedocs.io/en/stable/contributed_packages/doe/doe.html) is a great information and a different set of examples. You can also go through our reaction kinetics example, which is split into the [experiment abstraction](https://github.com/Pyomo/pyomo/blob/main/pyomo/contrib/doe/examples/reactor_experiment.py) and [execution example](https://github.com/Pyomo/pyomo/blob/main/pyomo/contrib/doe/examples/reactor_example.py).
 
 If you use Pyomo.DoE, please cite our paper:
 


### PR DESCRIPTION
**Motivation:** 
- The reaction example link in the `README.md` was broken since the `.ipynb` script was deleted from `pyomo/contrib/doe/examples`. This PR adds new links to that example from `pyomo/contrib/doe/examples`.
